### PR TITLE
FEAT: send-to-messenger-checkbox support

### DIFF
--- a/fbotics/__init__.py
+++ b/fbotics/__init__.py
@@ -21,7 +21,7 @@ class Client(object):
     def __init__(self, page_access_token=None):
         self.page_access_token = page_access_token
 
-    def send_text_message(self, recipient_id=None, text=None):
+    def send_text_message(self, recipient_id=None, text=None, user_ref=None):
         """Sends a simple text message to a given recipient.
 
         # Arguments
@@ -34,7 +34,7 @@ class Client(object):
         ```
         """
         message = Message({"text": text})
-        recipient = Recipient({"id": recipient_id})
+        recipient = Recipient({"id": recipient_id, "user_ref": user_ref})
         request = Request({"recipient": recipient, "message": message})
         # throws DataError if validation fails
         request.validate()

--- a/fbotics/models/recipient.py
+++ b/fbotics/models/recipient.py
@@ -4,6 +4,6 @@ from schematics.types import StringType
 
 # TODO: Add missing fields and constraints
 class Recipient(Model):
-    id = StringType(required=True)
-    phone_number = StringType(required=False)
-    user_ref = StringType(required=False)
+    id = StringType(required=False, serialize_when_none=False)
+    phone_number = StringType(required=False, serialize_when_none=False)
+    user_ref = StringType(required=False, serialize_when_none=False)


### PR DESCRIPTION
I have set 'serialize_when_none=False' for the recipient-model, because the structure of send-to-messenger-messages does not contain the user_id attribute. Instead it contains the user_ref attribute.
